### PR TITLE
Add --track/-t option to enable external state tracking

### DIFF
--- a/src/binding.c
+++ b/src/binding.c
@@ -245,7 +245,15 @@ void binding_activate(Binding_t *self) {
   switch(self->action) {
 
   case XC_ACTION_ENTER:
+    if (xc->track) {
+        printf("TRACK enter\n");
+	fflush(stdout);
+    }
     binding_enter(self);
+    if (xc->track) {
+        printf("TRACK exit\n");
+	fflush(stdout);
+    }
     break;
 
   case XC_ACTION_ESCAPE:
@@ -261,7 +269,15 @@ void binding_activate(Binding_t *self) {
     break;
 
   case XC_ACTION_GROUP:
+    if (xc->track) {
+        printf("TRACK group enter %s\n", self->name);
+	fflush(stdout);
+    }
     binding_group(self);
+    if (xc->track) {
+        printf("TRACK group exit %s\n", self->name);
+	fflush(stdout);
+    }
     break;
 
   case XC_ACTION_LOAD:
@@ -277,6 +293,9 @@ int binding_wait_event(Binding_t *self) {
     struct timeval tv1, tv2, *delay_tv, *timeout_tv;
     fd_set in;
     int ignore_delay = False;
+
+    if (XPending(xc->display))
+        return True;
 
     if (xc->delay > 0) {
         if (self->timeout > 0 && xc->delay > self->timeout) {

--- a/src/util.c
+++ b/src/util.c
@@ -26,6 +26,7 @@ void usage() {
   printf("  -f, --file    : alternative config file\n");
   printf("  -k, --keys    : Show valid keyspecs\n");
   printf("  -d, --debug   : Enable debug messages\n");
+  printf("  -t, --track   : Track entry/exit to stdout\n");
   printf("  -h, --help    : Print this help text\n");
   printf("  -v, --version : Print version information\n");
   printf("\n");

--- a/src/xchainkeys.c
+++ b/src/xchainkeys.c
@@ -59,6 +59,7 @@ XChainKeys_t* xc_new() {
   XSetErrorHandler(xc_handle_error);
 
   self->debug = False;
+  self->track = False;
   self->timeout = 3000;
   self->delay = 1000;
   self->hold = -1;
@@ -622,13 +623,14 @@ void xc_parse_options(XChainKeys_t *self, int argc, char **argv) {
     { "version", no_argument, NULL, 'v' },
     { "keys", no_argument, NULL, 'k' },
     { "file", no_argument, NULL, 'f' },
+    { "track", no_argument, NULL, 't' },
     { 0, 0, 0, 0 },
   };
   int option, option_index;
 
   while (1) {
 
-    option = getopt_long(argc, argv, "dhvkf:", options, &option_index);
+    option = getopt_long(argc, argv, "dhvkf:t", options, &option_index);
     
     switch (option) {
 
@@ -641,6 +643,12 @@ void xc_parse_options(XChainKeys_t *self, int argc, char **argv) {
       xc_show_keys(self);
       exit(EXIT_SUCCESS);
 
+    case 't':
+      self->track = True;
+      version();
+      printf("\n"); fflush(stdout);
+      break;
+      
     case 'd':
       self->debug = True;
       version();

--- a/src/xchainkeys.h
+++ b/src/xchainkeys.h
@@ -22,6 +22,7 @@ typedef struct XChainKeys {
   int debug;
   unsigned int timeout;
   unsigned int delay;
+  unsigned int track;
   unsigned int hold;
   int connection;
   char *position;


### PR DESCRIPTION
Useful when using it as a key binding front end for e.g. i3, which allows you to have modal and non-modal bindings and not use i3's bindings. If you also use e.g. polybar, then you can pipe the output into an indicator on the status bar showing when a binding capture is active.

Also fix binding_event_wait to not wait if XPending(...) returns true.